### PR TITLE
Minor freelist stuff

### DIFF
--- a/src/malloc_freelist.c
+++ b/src/malloc_freelist.c
@@ -20,7 +20,7 @@
 
 /*
  * This is the container for our free-list.
- * Node the usage of the linked list here: the library uses offsetof
+ * Note the usage of the linked list here: the library uses offsetof
  * and container_of to manage the list and get back to the parent struct.
  */
 typedef struct

--- a/test/src/malloc_freelist.c
+++ b/test/src/malloc_freelist.c
@@ -45,7 +45,7 @@ static void malloc_test(void** __attribute__((unused)) state)
 	ptr = malloc(2 * mem_block_size);
 	assert_null(ptr);
 
-	for(int i = 0; i < ALLOCATION_TEST_COUNT; i++)
+	for(size_t i = 0; i < ALLOCATION_TEST_COUNT; i++)
 	{
 		p[i] = malloc(1024);
 		assert_non_null(p[i]);
@@ -53,13 +53,13 @@ static void malloc_test(void** __attribute__((unused)) state)
 	}
 
 	// Cleanup
-	for(int i = 0; i < ALLOCATION_TEST_COUNT; i++)
+	for(size_t i = 0; i < ALLOCATION_TEST_COUNT; i++)
 	{
 		free(p[i]);
 	}
 
 	// Run test again, will not fail if our memory has been returned!
-	for(int i = 0; i < ALLOCATION_TEST_COUNT; i++)
+	for(size_t i = 0; i < ALLOCATION_TEST_COUNT; i++)
 	{
 		p[i] = malloc(1024);
 		assert_non_null(p[i]);
@@ -67,7 +67,7 @@ static void malloc_test(void** __attribute__((unused)) state)
 	}
 
 	// Cleanup
-	for(int i = 0; i < ALLOCATION_TEST_COUNT; i++)
+	for(size_t i = 0; i < ALLOCATION_TEST_COUNT; i++)
 	{
 		free(p[i]);
 	}

--- a/test/src/malloc_freelist.c
+++ b/test/src/malloc_freelist.c
@@ -50,6 +50,9 @@ static void malloc_test(void** __attribute__((unused)) state)
 		p[i] = malloc(1024);
 		assert_non_null(p[i]);
 		assert_in_range((uintptr_t)p[i], mem_block_addr, mem_block_end_addr);
+		// Test for unique addresses
+		if(i > 0)
+			assert_not_in_set((uintptr_t)p[i], (uintptr_t*)p, i - 1);
 	}
 
 	// Cleanup
@@ -64,6 +67,8 @@ static void malloc_test(void** __attribute__((unused)) state)
 		p[i] = malloc(1024);
 		assert_non_null(p[i]);
 		assert_in_range((uintptr_t)p[i], mem_block_addr, mem_block_end_addr);
+		if(i > 0)
+			assert_not_in_set((uintptr_t)p[i], (uintptr_t*)p, i - 1);
 	}
 
 	// Cleanup


### PR DESCRIPTION
Hi,

I have made some minor changes to the freelist implementation and its tests. The tests could be further enhanced by varying the sizes and also checking for non-overlapping blocks but I don't intend to do that.

The last change might be controversial. It changes the scope of `struct ll_head free_list` to be global instead of limited to compilation unit. I require this to be able to manipulate the metadata outside of the implementation for a research project. I was looking for alternatives to change the visibility of this kind of variables but it's basically impossible to do this - not even by external tools re-writing static libraries/object files. One might be able to implement such a tool but it's certainly not trivial.
Newlib's metadata is usually also global (depending on how it's compiled) but that's of course a weak argument. If you see problems with simply making it global maybe we could make it configurable?