### PR TITLE
Add a build option that can be used to override the free list static declaration

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,5 @@ option('libc-subproject', type: 'array',
     value: ['libc', 'libc_dep', 'libc_hosted_native_dep'],
     yield: true, 
     description: 'This array is used in combination with use-libc-subproject. The first entry is the subproject name. The second is the cross-compilation dependency to use. The third value is optional. If used, it is a native dependency to use with native library targets.')
+option('freelist-declared-static', type:'boolean', value: true, yield: true,
+    description: 'Set to false to make the freelist data structure accessible outside of the malloc_freelist.c file. By default, it has static linkage.')

--- a/src/malloc_freelist.c
+++ b/src/malloc_freelist.c
@@ -8,6 +8,17 @@
 #include <memory.h>
 #include <stdint.h>
 
+/// By default, the freelist is declared as static so that it cannot be accessed
+/// outside of the library. Users who wish to override this default declaration
+/// can define `FREELIST_DECL_SPECIFIERS` to use an alternative.
+/// One option is to make it an empty definition to make it publicly visible,
+/// which may be useful for capturing state or performing metadata analysis.
+///
+/// Unless you have a specific use case, we recommend sticking with the default.
+#ifndef FREELIST_DECL_SPECIFIERS
+#define FREELIST_DECL_SPECIFIERS static
+#endif
+
 #pragma mark - Definitions -
 
 /**
@@ -70,7 +81,7 @@ void malloc_unlock();
 #pragma mark - Declarations -
 
 // This macro simply declares and initializes our linked list
-static LIST_INIT(free_list);
+FREELIST_DECL_SPECIFIERS LIST_INIT(free_list);
 
 #pragma mark - Private Functions -
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -134,9 +134,18 @@ libmemory_assert_native_dep = declare_dependency(
 # Freelist #
 ############
 
+freelist_compile_args = []
+if get_option('freelist-declared-static') == false
+	# Remove the static declaration option from the free list struct
+	# The = with an empty string is needed to prevent the compiler
+	# from unhelpfully making it FREELIST_DECL_SPECIFIERS=1 on our behalf
+	freelist_compile_args += '-DFREELIST_DECL_SPECIFIERS='
+endif
+
 libmemory_freelist = static_library(
 	'memory_freelist',
 	[common_files, 'malloc_freelist.c'],
+	c_args: freelist_compile_args,
 	include_directories: [libmemory_includes, dependency_includes],
 	dependencies: libc_dep,
 	# Do not built by default if we are a subproject
@@ -146,6 +155,7 @@ libmemory_freelist = static_library(
 libmemory_freelist_native = static_library(
 	'memory_freelist_native',
 	[common_files, 'malloc_freelist.c'],
+	c_args: freelist_compile_args,
 	include_directories: [libmemory_includes, dependency_includes],
 	dependencies: libc_native_dep,
 	native: true,


### PR DESCRIPTION
Fixes #84

## Example Output from a manual test case

Default, with a test case that tries to access the list in another file:

```
[2/2] Linking target test/libmemory_freelist_test
FAILED: test/libmemory_freelist_test
cc  -o test/libmemory_freelist_test test/libmemory_freelist_test.p/main.c.o test/libmemory_freelist_test.p/support_memory.c.o test/libmemory_freelist_test.p/src_aligned_malloc.c.o test/libmemory_freelist_test.p/src_malloc_freelist.c.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,error -Wl,-rpath,@loader_path/../subprojects/cmocka-1.1.5/src subprojects/cmocka-1.1.5/src/libcmocka_native.0.dylib src/libmemory_freelist_native.a
Undefined symbols for architecture x86_64:
  "_free_list", referenced from:
      _malloc_test in src_malloc_freelist.c.o
```

After `$ make OPTIONS=-Dfreelist-declared-static=false`, the application will link successfully and we can iterate over the free list.
