### PR TITLE
Add alignment block splitting to malloc_freelist

### DIFF
--- a/include/aligned_malloc.h
+++ b/include/aligned_malloc.h
@@ -16,8 +16,6 @@ extern "C" {
  * @brief Allocated aligned memory
  *
  * Allocate memory with at least alignment `align` and size `size`
- * 	Memory which has been allocated with aligned_malloc() must be freed by calling
- *	aligned_free(). Calling free() will result in a panic or other negative effects.
  *
  * @param align Alignment of the memory block.
  *	Alignment refers to the starting address of the memory block.
@@ -59,10 +57,9 @@ void* aligned_malloc(size_t align, size_t size);
 /** Posix Memory Alignment Extension
  *
  * Generated aligned memory. This function forwards the request to aligned malloc.
- * Allocated memory must be freed with aligned_free().
  *
- * @param memptr A pointer to the pointer which will store the aligned memory. The
- *	memory must be freed with aligned_free(). memptr must not be NULL.
+ * @param memptr A pointer to the pointer which will store the aligned memory.
+ * memptr must not be NULL.
  * @param alignment The target alignment for the memory. Must be a power of 2.
  * @param size The size of the allocation. Must be > 0.
  *
@@ -77,8 +74,13 @@ int posix_memalign(void** memptr, size_t alignment, size_t size);
  * @brief Free aligned memory
  *
  * Free memory that was allocated using aligned_malloc().
- * 	This function *must not* be called on memory which was not allocated
- * 	with aligned_malloc().
+ *
+ * This function is kept for compatibility and it simply calls free().
+ * The main allocator now splits blocks to align them making aligned_free
+ * redundant. It was previously necessary to unwrap an offset field in a
+ * wrapper header but now the regular header block is aligned so that free
+ * can be called directly on aligned allocations and the excess alignment
+ * slack is now added to the freelist instead of wasted.
  *
  * @param ptr Pointer to the aligned_memory() block that will be freed.
  */


### PR DESCRIPTION
## Description

The main allocator is modified to split blocks to align them, returning surplus to the free list.

I am sharing this because I think this approach is a little cleaner than the existing approach. It has several advantages and adds minimal complexity. It has been tested locally but it needs more testing and review. The primary code path should be unchanged for regular allocations besides dropping the minimum allocation size and calculating _alignment_slack_ which should always be zero for regular allocations.

The fundamental algorithm is mostly unchanged although there is additional logic to calculate _alignment_slack_ in the case that the alignment is greater than the alignment of the found block. If _alignment_slack_ is non-zero it is used to split the block so that block is sufficiently aligned with the surplus returned to the free list. Some indent has been removed for readability.

_aligned_free_ is now redundant but it is kept for compatibility. It is no longer necessary to unwrap an offset field in wrapper headers as the main allocation header block is aligned and free can be called directly on aligned allocations, so _aligned_free_ now simply delegates to free(). Also, the surplus memory to align blocks is not wasted and can be allocated.

This changes needs rigorous testing and review. This is a heads up!

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update which has been made
  - The change is backwards compatible but it relaxes requirements for _aligned_free_.

## How Has This Been Tested?

- [X] Test A - The internal `libmemory_freelist_test` test passes.
- [X] Test B - The code is used in a kernel that requires aligned allocations and appears to function correctly.

**Test Configuration**:
* Project version/commit: f758bd4a4934ce3bd7931049e1ce61ddb40c367a
* Hardware: Intel Skylake i9
* Toolchain: Ubuntu/GCC

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
